### PR TITLE
Integración RAG

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -9,5 +9,9 @@ class Settings:
     VERSION: str = "0.1.0"
     DEBUG: bool = True
     GROQ_API_KEY: str = os.getenv("GROQ_API_KEY", "")
-
+    #supabase :
+    SUPABASE_URL: str = os.getenv("SUPABASE_URL", "")
+    SUPABASE_KEY: str = os.getenv("SUPABASE_KEY", "")
+    SUPABASE_BUCKET: str = os.getenv("SUPABASE_BUCKET", "nifi-docs")
+    
 settings = Settings()

--- a/backend/app/rag/indexer.py
+++ b/backend/app/rag/indexer.py
@@ -1,0 +1,69 @@
+import os
+from typing import List, Tuple
+from datetime import datetime
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_community.vectorstores import FAISS
+from supabase import create_client
+from app.core.config import settings
+from langchain_openai import OpenAIEmbeddings
+from langchain_community.embeddings import HuggingFaceEmbeddings
+from .parsers import parse_by_extension
+
+supabase = create_client(settings.SUPABASE_URL, settings.SUPABASE_KEY)
+BUCKET = settings.SUPABASE_BUCKET
+
+INDEX_DIR = os.getenv("RAG_INDEX_DIR", "data/rag_index_faiss")
+ALLOWED_EXT = {".txt", ".md", ".csv", ".xml", ".pdf"}
+
+def _embedding_model():
+    if os.getenv("OPENAI_API_KEY"):
+        return OpenAIEmbeddings()
+    return HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+
+def _chunk_text(text: str) -> List[str]:
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=1000, chunk_overlap=150, separators=["\n\n", "\n", " ", ""]
+    )
+    return splitter.split_text(text)
+
+def _list_bucket_files(path: str = "") -> List[str]:
+    entries = supabase.storage.from_(BUCKET).list(path)
+    files = []
+    for e in entries:
+        if e["name"].lower().endswith(tuple(ALLOWED_EXT)):
+            files.append(f"{path}/{e['name']}" if path else e["name"])
+    return files
+
+def _download_file(name: str) -> bytes:
+    return supabase.storage.from_(BUCKET).download(name)
+
+def _metadata_for(name: str) -> dict:
+    return {"source": f"supabase://{BUCKET}/{name}", "ingested_at": datetime.utcnow().isoformat() + "Z"}
+
+def rebuild_index() -> Tuple[FAISS, int]:
+    files = _list_bucket_files()
+    print("DEBUG Supabase list:", files)
+    if not files:
+        raise RuntimeError("No se encontraron archivos en el bucket de Supabase")
+
+    docs, metadatas = [], []
+    for fname in files:
+        raw = _download_file(fname)
+        txt = parse_by_extension(fname, raw)
+        chunks = _chunk_text(txt)
+        meta = _metadata_for(fname)
+        docs.extend(chunks)
+        metadatas.extend([meta] * len(chunks))
+
+    embeddings = _embedding_model()
+    db = FAISS.from_texts(docs, embeddings, metadatas=metadatas)
+    os.makedirs(INDEX_DIR, exist_ok=True)
+    db.save_local(INDEX_DIR)
+    return db, len(docs)
+
+def ensure_index() -> FAISS:
+    embeddings = _embedding_model()
+    if os.path.isdir(INDEX_DIR) and os.path.exists(os.path.join(INDEX_DIR, "index.faiss")):
+        return FAISS.load_local(INDEX_DIR, embeddings, allow_dangerous_deserialization=True)
+    db, _ = rebuild_index()
+    return db

--- a/backend/app/rag/parsers.py
+++ b/backend/app/rag/parsers.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+import csv
+import io
+import re
+from typing import Iterable, List
+from pypdf import PdfReader
+
+def _clean_text(text: str) -> str:
+    text = text.replace("\x00", " ").strip()
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text
+
+def parse_txt(data: bytes) -> str:
+    return _clean_text(data.decode("utf-8", errors="ignore"))
+
+def parse_md(data: bytes) -> str:
+    return _clean_text(data.decode("utf-8", errors="ignore"))
+
+def parse_xml(data: bytes) -> str:
+    txt = data.decode("utf-8", errors="ignore")
+    attrs = re.findall(r'(?:name|type)="([^"]+)"', txt)
+    stripped = re.sub(r"<[^>]+>", " ", txt)
+    combined = "\n".join(attrs + [stripped])
+    return _clean_text(combined)
+
+def parse_csv(data: bytes) -> str:
+    buff = io.StringIO(data.decode("utf-8", errors="ignore"))
+    reader = csv.DictReader(buff)
+    lines: List[str] = []
+    for row in reader:
+        parts = []
+        for k, v in row.items():
+            if k and v and str(v).strip():
+                parts.append(f"{k.strip()}: {str(v).strip()}")
+        if parts:
+            lines.append(" | ".join(parts))
+    return _clean_text("\n".join(lines))
+
+def parse_pdf(data: bytes) -> str:
+    with io.BytesIO(data) as bio:
+        reader = PdfReader(bio)
+        pages = []
+        for p in reader.pages:
+            pages.append(p.extract_text() or "")
+        return _clean_text("\n\n".join(pages))
+
+def parse_by_extension(filename: str, data: bytes) -> str:
+    name = filename.lower()
+    if name.endswith(".txt"):
+        return parse_txt(data)
+    if name.endswith(".md"):
+        return parse_md(data)
+    if name.endswith(".xml"):
+        return parse_xml(data)
+    if name.endswith(".csv"):
+        return parse_csv(data)
+    if name.endswith(".pdf"):
+        return parse_pdf(data)
+    return parse_txt(data)

--- a/backend/app/rag/query.py
+++ b/backend/app/rag/query.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+from typing import List
+from .indexer import ensure_index
+
+def rag_search(query: str, k: int = 5):
+    db = ensure_index()
+    return db.similarity_search(query, k=k)
+
+def get_context_for_agents(query: str, k: int = 5, sep: str = "\n---\n") -> str:
+    docs = rag_search(query, k=k)
+    parts = []
+    for d in docs:
+        src = d.metadata.get("source", "unknown")
+        parts.append(f"[Fuente: {src}]\n{d.page_content}")
+    return sep.join(parts)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,3 +18,9 @@ pytest
 black
 flake8
 requests
+supabase
+langchain-community
+faiss-cpu
+pypdf
+langchain-openai
+sentence-transformers

--- a/backend/tests/test_rag.py
+++ b/backend/tests/test_rag.py
@@ -1,0 +1,29 @@
+import pytest
+import os
+from dotenv import load_dotenv
+
+load_dotenv()  
+
+from app.rag import indexer
+
+# verificamos variables primero
+def test_env_variables():
+    assert os.getenv("SUPABASE_URL"), "Falta SUPABASE_URL en .env"
+    assert os.getenv("SUPABASE_KEY"), "Falta SUPABASE_KEY en .env"
+    assert os.getenv("SUPABASE_BUCKET"), "Falta SUPABASE_BUCKET en .env"
+
+# verificamos que el bucket contenga archivos
+def test_list_bucket_files():
+    files = indexer._list_bucket_files()
+    assert isinstance(files, list)
+    assert all(isinstance(f, str) for f in files)
+    assert any(f.endswith(".csv") for f in files), "No se encontró ningún CSV en el bucket"
+
+# verificamos que se pueda reconstruir un índice FAISS
+def test_rebuild_index(tmp_path):
+    indexer.INDEX_DIR = str(tmp_path / "rag_index_faiss")
+
+    db, n_chunks = indexer.rebuild_index()
+    assert db is not None
+    assert n_chunks > 0
+    assert os.path.exists(os.path.join(indexer.INDEX_DIR, "index.faiss"))

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -7,7 +7,7 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
-frontend/node_modules
+node_modules
 dist
 dist-ssr
 *.local
@@ -22,9 +22,3 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-
-<<<<<<< HEAD:frontend/.gitignore
-=======
-node_modules/
-
->>>>>>> c9204cf (Feature/Frontend):.gitignore


### PR DESCRIPTION
**Archivos añadidos/cambiados en este PR**

- backend/app/core/config.py → añadidas variables de entorno para Supabase (SUPABASE_URL, SUPABASE_KEY, SUPABASE_BUCKET).

- backend/app/rag/indexer.py → creación del índice FAISS a partir de documentos en Supabase.

- backend/app/rag/parsers.py → parsers para TXT, MD, CSV, XML y PDF.

- backend/app/rag/query.py → funciones públicas rag_search y get_context_for_agents.
 
- backend/tests/test_rag.py → tests básicos para validar entorno, listar archivos en Supabase y reconstrucción de índice FAISS.

- backend/requirements.txt → añadidas dependencias: supabase, faiss-cpu, pypdf, langchain-community, langchain-openai, sentence-transformers.

**Integración de RAG (Retrieval-Augmented Generation) en la tare de los agentes**

**Archivo a usar:**
app/rag/query.py

**Funciones clave**

- rag_search(query: str, k: int = 5)

Devuelve los documentos más similares como objetos (texto + metadatos).

- get_context_for_agents(query: str, k: int = 5)

Devuelve un bloque de texto ya listo con citas que puedes inyectar en la descripción del Task.

**Ejemplo de uso en un Task**

En nifi_migration_tasks.py, dentro de un Task (por ejemplo mapping_task):

```python
from app.rag.query import get_context_for_agents
from app.prompts import MAPPING_TASK_DESCRIPTION, MAPPING_TASK_EXPECTED_OUTPUT
from crewai import Task

def mapping_task(agent, context_task):
    # Buscar contexto en la documentación oficial mediante RAG
    contexto_docs = get_context_for_agents("NiFi 1.x to 2.x migration", k=5)

    return Task(
        description=f"""{MAPPING_TASK_DESCRIPTION}

### Contexto de Documentación Oficial
{contexto_docs}""",
        expected_output=MAPPING_TASK_EXPECTED_OUTPUT,
        agent=agent,
        context=[context_task],
    )
````


**Con esto:**

- El agente recibe el contexto del RAG como parte de su prompt.
 
- No cambia nada más en los agentes ni en Crew.
 
- Si mañana pasamos de FAISS a Chroma, solo hay que cambiar en indexer.py, no en los agentes.



**Importante**

- El backend no necesita cambios en endpoints ni servicios → /api/v1/analyze sigue siendo el mismo.
- 
- El RAG se integra únicamente en los Tasks de Crew, añadiendo el contexto de documentación oficial en las descripciones.